### PR TITLE
Add missing window hints

### DIFF
--- a/glfw.py
+++ b/glfw.py
@@ -276,6 +276,7 @@ GLFW_ICONIFIED              = 0x00020002
 GLFW_RESIZABLE              = 0x00020003
 GLFW_VISIBLE                = 0x00020004
 GLFW_DECORATED              = 0x00020005
+GLFW_AUTO_ICONIFY           = 0x00020006
 
 # ---
 GLFW_RED_BITS               = 0x00021001

--- a/glfw.py
+++ b/glfw.py
@@ -277,6 +277,7 @@ GLFW_RESIZABLE              = 0x00020003
 GLFW_VISIBLE                = 0x00020004
 GLFW_DECORATED              = 0x00020005
 GLFW_AUTO_ICONIFY           = 0x00020006
+GLFW_FLOATING               = 0x00020007
 
 # ---
 GLFW_RED_BITS               = 0x00021001


### PR DESCRIPTION
These hints were missing from the definitions. I took the values from https://github.com/glfw/glfw/blob/master/include/GLFW/glfw3.h#L633

Tested on Python3, but it should also work on Python2